### PR TITLE
Update install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,25 +23,21 @@
 ![Revolve](https://raw.githubusercontent.com/self-evolving-runtimes/revolve/refs/heads/main/screenshots/animated.gif)
 
 ---
-### Pre-requisites
-- Python 3.11
-- OPENAI API Key
-- PostgreSQL database with tables
+### Installation
 
-### Quick Start
-
-#### 1. Install Dependencies
+Install the package from PyPI:
 
 ```sh
-brew install uv
-uv sync
+pip install selfrevolve
 ```
 
-#### 2. Start
+Run the API and UI:
 
 ```sh
-python src/revolve/api.py
+revolve-api
 ```
+
+For local development instructions, see [contributor-README.md](contributor-README.md).
 
 
 ### Roadmap

--- a/contributor-README.md
+++ b/contributor-README.md
@@ -22,6 +22,13 @@ It uses the generated apps in a modern react UI to enable CRUD operations on tab
 
 ---
 
+## Pre-requisites
+- Python 3.11
+- OPENAI API Key
+- PostgreSQL database with tables
+
+---
+
 ## Quick Start
 
 ### 1. Install Dependencies


### PR DESCRIPTION
## Summary
- document PyPI install (`pip install selfrevolve`) in README
- move development setup & python commands to contributor docs
